### PR TITLE
Normalizing S3 paths for Windows

### DIFF
--- a/lib/utils/initFile.js
+++ b/lib/utils/initFile.js
@@ -1,9 +1,11 @@
 "use strict";
 
+var path = require("path");
+
 module.exports = function (file) {
     if ( file.s3 ) { return; }
 
     file.s3 = {};
     file.s3.headers = {};
-    file.s3.path = file.path.replace(file.base, "");
+    file.s3.path = file.path.replace(file.base, "").replace(new RegExp("\\" + path.sep, "g"), "/");
 };

--- a/test/awspublishRouterSpec.js
+++ b/test/awspublishRouterSpec.js
@@ -2,6 +2,7 @@
 
 var awspublishRouter = require("../index.js");
 var File = require("vinyl");
+var path = require("path");
 
 var createFile = function (options) {
     var file = new File(options);
@@ -352,6 +353,25 @@ describe("awspublishRouter", function () {
         stream.write(file);
         file.s3.path.should.equal("bar.html");
         file.s3.headers.should.deep.equal({});
+    });
+
+    it("should normalize paths when initializing awspublish options for the file", function () {
+        var stream = awspublishRouter({
+            routes: {
+                "^.+$": {
+                    key: "$&"
+                }
+            }
+        });
+
+        var file = new File({
+            path: path.join("foo", "bar", "baz", "qux.html"),
+            base: path.join("foo", path.sep),
+            contents: new Buffer("meow")
+        });
+
+        stream.write(file);
+        file.s3.path.should.equal("bar/baz/qux.html");
     });
 
     it("should ignore empty files / directories (issue #1)", function (callback) {


### PR DESCRIPTION
This mirrors the fix made in pgherveou/gulp-awspublish#36 for `initFile()`, and prevents files from being uploaded to the bucket root with backslashes throughout the filename instead of into their proper folders. Since this plugin goes in the pipeline before `gulp-awspublish`, the other fix is bypassed and we need to take care of it here.