### PR TITLE
Allow RegExp matching in route-specific headers.

### DIFF
--- a/index.js
+++ b/index.js
@@ -44,15 +44,14 @@ module.exports = function (options) {
             return route.routeMatcher.test(file.relative);
         });
 
-        var headers = {}
-        for ( var k in route.headers ) {
-            headers[k] = file.s3.path.replace(route.routeMatcher, route.headers[k])
-            console.log(file.s3.path + ' - ' + k + ': ' + route.headers[k] + ' --> ' + headers[k])
-        }
+        var extraHeaders = {};
+        _.each(route.headers, function(val, key) {
+            extraHeaders[key] = file.s3.path.replace(route.routeMatcher, val);
+        });
 
         file.s3.path = file.s3.path.replace(route.routeMatcher, route.key);
         applyCacheHeaders(file, route);
-        _.extend(file.s3.headers, headers);
+        _.extend(file.s3.headers, extraHeaders);
 
         if ( route.gzip ) {
             if ( route.gzip === true ) {

--- a/index.js
+++ b/index.js
@@ -44,9 +44,15 @@ module.exports = function (options) {
             return route.routeMatcher.test(file.relative);
         });
 
+        var headers = {}
+        for ( var k in route.headers ) {
+            headers[k] = file.s3.path.replace(route.routeMatcher, route.headers[k])
+            console.log(file.s3.path + ' - ' + k + ': ' + route.headers[k] + ' --> ' + headers[k])
+        }
+
         file.s3.path = file.s3.path.replace(route.routeMatcher, route.key);
         applyCacheHeaders(file, route);
-        _.extend(file.s3.headers, route.headers);
+        _.extend(file.s3.headers, headers);
 
         if ( route.gzip ) {
             if ( route.gzip === true ) {

--- a/test/awspublishRouterSpec.js
+++ b/test/awspublishRouterSpec.js
@@ -164,6 +164,28 @@ describe("awspublishRouter", function () {
         file.s3.headers["Content-Type"].should.equal("text/plain");
     });
 
+    it("should apply RegExp matches to route specific `headers`", function () {
+        var stream = awspublishRouter({
+            routes: {
+                "^(\\w+)+\\.html$": {
+                    headers: {
+                        "WebsiteRedirectLocation": "test-$1"
+                    }
+                }
+            }
+        });
+
+        var file = createFile({
+            path: "/foo/bar.html",
+            base: "/foo/",
+            contents: new Buffer("meow")
+        });
+
+        stream.write(file);
+        file.s3.headers["WebsiteRedirectLocation"].should.equal("test-bar");
+
+    });
+
     it("should apply cache headers according to the `cacheTime` value in the route, " +
             "using private and no-transform by default and no `Expires` header", createSimpleTest({
                 routes: {

--- a/test/awspublishRouterSpec.js
+++ b/test/awspublishRouterSpec.js
@@ -183,7 +183,6 @@ describe("awspublishRouter", function () {
 
         stream.write(file);
         file.s3.headers["WebsiteRedirectLocation"].should.equal("test-bar");
-
     });
 
     it("should apply cache headers according to the `cacheTime` value in the route, " +


### PR DESCRIPTION
In particular, we're using this for relative WebsiteRedirectLocation properties.