### PR TITLE
Fix Expires header invalid date format

### DIFF
--- a/lib/utils/applyCacheHeaders.js
+++ b/lib/utils/applyCacheHeaders.js
@@ -18,7 +18,7 @@ module.exports = function (file, route) {
         file.s3.headers["Cache-Control"] = directives.join(", ");
 
         if ( route.useExpires ) {
-            file.s3.headers.Expires = new Date(Date.now() + route.cacheTime * 1000).toUTCString();
+            file.s3.headers.Expires = new Date(Date.now() + route.cacheTime * 1000);
         }
     }
 };

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "gulp-awspublish-router",
-  "version": "0.1.1",
+  "version": "0.1.2",
   "description": "Define your build sources in HTML.",
   "main": "index.js",
   "directories": {


### PR DESCRIPTION
Fix the problem when use `useExpires : true` option.
```
InvalidParameterType: Expected params.Expires to be a Date object, ISO-8601 string, or a UNIX timestamp
```